### PR TITLE
use access token instead of credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Raygun dSYM Upload step for [Bitrise](http://bitrise.io) enabled to you automati
 ## Important information
 There are three parameters that must be filled in:
 
-* **raygun_api_key**: This is a Base64 encode of your username:password, you can run the following command in the terminal: ```echo -n 'username:password | openssl base64``` to get it. This is the username and password to Raygun.
+* **raygun_access_token**: External access token can be obtained from Raygun by clicking your name in the top right corner, select "My settings" and then hit "Generate external access token" or copy it if you already have one.
 * **dsym_path**: This is th path to the dSYM zip, automatically set to the default Bitrise path
 * **app_id**: This is the App Id is in the URL to your app when you view it in Raygun. It is usually 6 characters long.
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,7 +11,7 @@ workflows:
     - path::./:
         title: Upload dSYM to Raygun
         inputs:
-        - raygun_api_key: $raygun_api_key
+        - raygun_access_token: $raygun_access_token
         - dsym_path: $dsym_path
         - app_id: $app_id
 # ----------------------------------------------------------------
@@ -32,7 +32,7 @@ workflows:
       # if you want to share this step into a StepLib
       - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
       - STEP_ID_IN_STEPLIB: raygun
-      - STEP_GIT_VERION_TAG_TO_SHARE: 1.0.1
+      - STEP_GIT_VERION_TAG_TO_SHARE: 1.1.0
       - STEP_GIT_CLONE_URL: https://github.com/jamesmontemagno/bitrise-step-raygun-dsym-upload.git
     description: |-
       If this is the first time you try to share a Step you should

--- a/step.sh
+++ b/step.sh
@@ -39,4 +39,4 @@ fi
 printf "\e[34mUploading ${zip_dsym_path} to Raygun\e[0m\n"
 
 
-curl -w "Upload returned: %{http_code}\\n" -H "Host: app.raygun.com" --form "DsymFile=@${dsym_path}" "https://app.raygun.com/dashboard/${app_id}/settings/symbols?authToken=${raygun_api_key}"
+curl -w "Upload returned: %{http_code}\\n" -H "Host: app.raygun.com" --form "DsymFile=@${dsym_path}" "https://app.raygun.com/dashboard/${app_id}/settings/symbols?authToken=${raygun_access_token}"

--- a/step.sh
+++ b/step.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-if [ -z "$raygun_api_key" ]; then
-	printf "\e[31mError: \e[0mraygun_api_key variable not set\n"
+if [ -z "$raygun_access_token" ]; then
+	printf "\e[31mError: \e[0mraygun_access_token variable not set\n"
 	exit 1
 fi
 
@@ -39,4 +39,4 @@ fi
 printf "\e[34mUploading ${zip_dsym_path} to Raygun\e[0m\n"
 
 
-curl -w "Upload returned: %{http_code}\\n" -H "Host: app.raygun.com" -H "Authorization: Basic ${raygun_api_key}" --form "DsymFile=@${dsym_path}" "https://app.raygun.com/dashboard/${app_id}/settings/symbols"
+curl -w "Upload returned: %{http_code}\\n" -H "Host: app.raygun.com" --form "DsymFile=@${dsym_path}" "https://app.raygun.com/dashboard/${app_id}/settings/symbols?authToken=${raygun_api_key}"

--- a/step.yml
+++ b/step.yml
@@ -16,11 +16,11 @@ is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
 inputs:
-  - raygun_api_key:
+  - raygun_access_token:
     opts:
-      title: API Key for Raygun. This is a Base64 encode of your username:password.
+      title: External access token for Raygun.
       description: |
-        This is a Base64 encode of your username:password, you can run the following command in the terminal - 'echo -n 'username:password | openssl base64' to get it
+        External access token can be obtained from Raygun by clicking your name in the top right corner, select "My settings" and then hit "Generate external access token" or copy it if you already have one.
       is_required: true
       is_expand: true
   - app_id:


### PR DESCRIPTION
I´m always getting 401 (forbidden) error from Raygun when I try to upload the symbols when using username:password (maybe some permission changed at Raygun?). However it works fine using raygun external token (explained here: https://raygun.com/docs/languages/ios). Besides, using an auth token feels more secure than credentials.